### PR TITLE
Optimal ChronicleMap<String, Set<String>> valueMarshaller configuration

### DIFF
--- a/src/main/java/com/maxdemarzi/ChronicleGraph.java
+++ b/src/main/java/com/maxdemarzi/ChronicleGraph.java
@@ -1,5 +1,8 @@
 package com.maxdemarzi;
 
+import net.openhft.chronicle.hash.serialization.SetMarshaller;
+import net.openhft.chronicle.hash.serialization.impl.CharSequenceBytesWriter;
+import net.openhft.chronicle.hash.serialization.impl.StringBytesReader;
 import net.openhft.chronicle.map.ChronicleMap;
 import net.openhft.chronicle.map.ExternalMapQueryContext;
 import net.openhft.chronicle.map.MapAbsentEntry;
@@ -56,12 +59,15 @@ public class ChronicleGraph {
             avgIncomingValue.add("some key" + i);
         }
 
+        SetMarshaller<String> cmValueMashaller = SetMarshaller
+                .of(new StringBytesReader(), CharSequenceBytesWriter.INSTANCE);
         ChronicleMap<String, Set<String>> cmOut = ChronicleMap
                 .of(String.class, (Class<Set<String>>) (Class) Set.class)
                 .name(type+ "-out")
                 .entries(maximum)
                 .averageValue(avgOutgoingValue)
                 .averageKey("one key - another key")
+                .valueMarshaller(cmValueMashaller)
                 .create();
         ChronicleMap<String, Set<String>> cmIn = ChronicleMap
                 .of(String.class, (Class<Set<String>>) (Class) Set.class)
@@ -69,6 +75,7 @@ public class ChronicleGraph {
                 .entries(maximum)
                 .averageValue(avgIncomingValue)
                 .averageKey("one key - another key")
+                .valueMarshaller(cmValueMashaller)
                 .create();
 
         related.put(type + "-out", cmOut);

--- a/src/test/java/com/maxdemarzi/ChronicleGraphBenchmark.java
+++ b/src/test/java/com/maxdemarzi/ChronicleGraphBenchmark.java
@@ -1,6 +1,10 @@
 package com.maxdemarzi;
 
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -160,4 +164,12 @@ public class ChronicleGraphBenchmark {
         db.getOutgoingRelationshipNodes("LIKES", "person" + rand.nextInt(personCount));
     }
 
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(ChronicleGraphBenchmark.class.getSimpleName() + ".measureCreateEmptyNodesAndRelationships")
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
 }


### PR DESCRIPTION
This change makes `measureCreateEmptyNodesAndRelationships` benchmark almost 3 times faster on my dev machine, 0.198 ops/s -> 0.577 ops/s